### PR TITLE
Remove global `util.main_event_loop`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,16 @@ jobs:
         python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy pytest .
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install mypy pytest .[dev]
 
       - name: Ruff static code analysis
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy pytest .[dev]
+          pip install mypy ruff pytest .[dev]
 
       - name: Ruff static code analysis
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
           pip install ruff mypy pytest .
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      - name: Flake8 static code analysis
-        run:
+      - name: Ruff static code analysis
+        run: |
           ruff check eventkit/
           ruff format eventkit/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 mypy pytest .
+          pip install ruff mypy pytest .
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Flake8 static code analysis
         run:
-          flake8 eventkit
+          ruff check eventkit/
+          ruff format eventkit/
 
       - name: MyPy static code analysis
         run: |

--- a/eventkit/event.py
+++ b/eventkit/event.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
 )
 
-from .util import NO_VALUE, get_event_loop, main_event_loop
+from .util import NO_VALUE, get_event_loop
 
 
 class Event:
@@ -240,7 +240,7 @@ class Event:
         Threadsafe version of :meth:`emit` that doesn't invoke the
         listeners directly but via the event loop of the main thread.
         """
-        main_event_loop.call_soon_threadsafe(self.emit, *args)
+        get_event_loop().call_soon_threadsafe(self.emit, *args)
 
     def clear(self):
         """

--- a/eventkit/util.py
+++ b/eventkit/util.py
@@ -21,9 +21,6 @@ def get_event_loop():
     return asyncio.get_event_loop_policy().get_event_loop()
 
 
-main_event_loop = get_event_loop()
-
-
 async def timerange(start=0, end=None, step: float = 1) -> AsyncIterator[dt.datetime]:
     """
     Iterator that waits periodically until certain time points are


### PR DESCRIPTION
as discussed on https://github.com/ib-api-reloaded/ib_async/discussions/62

remove `util.main_event_loop` global

update `event.Event`

```python
        get_event_loop().call_soon_threadsafe(self.emit, *args)
```


