### PR TITLE
fix issue #12 timeout is not forwarding it's source

### DIFF
--- a/eventkit/ops/timing.py
+++ b/eventkit/ops/timing.py
@@ -44,6 +44,7 @@ class Timeout(Op):
     def on_source(self, *args):
         loop = get_event_loop()
         self._last_time = loop.time()
+        Op.on_source(self, *args)
 
     def on_source_done(self, source):
         self._handle.cancel()

--- a/tests/timing_test.py
+++ b/tests/timing_test.py
@@ -23,6 +23,13 @@ class TimingTest(unittest.TestCase):
         self.assertEqual(event.run(), [2, 4, 6, 8])
 
     def test_timeout(self):
+        # source faster than timeout
+        seq = Event.sequence(array1, interval=0.01).timeout(0.1)
+        self.assertEqual(seq.run(), array1)
+        # source slower than timeout
+        seq2 = Event.sequence([1, 2, 3], interval=0.1).timeout(0.01)
+        self.assertEqual(seq2.run(), [1, Event.NO_VALUE])
+        # plain timeout
         timer = Event.timer(10, count=1)
         event = timer.timeout(0.01)
         self.assertEqual(event.run(), [Event.NO_VALUE])


### PR DESCRIPTION
Operator timeout is not re-emiting source emits, this fix will set timeout operator so it's emits from its source unless it times-out from the previous emit.

Updated tests to show the case where there is no timeout, a timeout after a first emit and a timeout with no emits.